### PR TITLE
update: Fixed compile warning regarding getcwd

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -1,9 +1,11 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cerrno>
 #include <stdio.h>
 #include <unistd.h>
 #include <sys/types.h>
+#include <sys/param.h>
 #include <pwd.h>
 
 #include "x.hpp"
@@ -102,10 +104,14 @@ int main( int argc, char** argv ) {
     std::string file = "";
     // If we don't have a file, default to writing to the home directory.
     if ( options.inputs_num <= 0 ) {
-        char currentdir[512];
+        char currentdir[MAXPATHLEN];
         // FIXME: getcwd is fundamentally broken, switch it with a C++ equivalent that won't ever have
         // buffer sizing issues.
-        getcwd( currentdir, 512 );
+        char* error = getcwd( currentdir, MAXPATHLEN );
+        if ( error == NULL ) {
+            fprintf( stderr, "Failed to get current working directory!\n" );
+            return errno;
+        }
         file = currentdir;
         std::string result;
         err = exec( "date +%F-%T", &result );


### PR DESCRIPTION
- Used MAXPATHLEN to avoid issues with buffer size for current working
  directory
- Handled the return value of `getcwd` which previously caused a
  compile-time warning.

Signed-off-by: mr.Shu mr@shu.io

------------ >8 ------------

This should help with the FIXME you've left in the code. I've ran into this while installing maim:

```
g++ -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2  -c -o main.o main.cpp
main.cpp: In function ‘int main(int, char**)’:
main.cpp:108:34: warning: ignoring return value of ‘char* getcwd(char*, size_t)’, declared with attribute warn_unused_result [-Wunused-result]
         getcwd( currentdir, 512 );
                                  ^
```

This should presumably fix it.

Also please note that the inclusion of `<sys/param.h>` is necessary for `MAXPATHLEN` and similarly `<cerrno>` is necessary for `errno`.

Regarding that FIXME comment: in my view this is as safe as it gets. You would need some C++ framework to use a real C++ equivalent.
