### PR TITLE
maim is now available in Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ In review, maim does one thing and does it well: it takes a screenshot of what y
 ### Install using your Package Manager (preferred)
 
 * [Arch Linux: community/maim](https://www.archlinux.org/packages/community/x86_64/maim/)
+* [Void Linux: maim](https://github.com/voidlinux/void-packages/blob/24ac22af44018e2598047e5ef7fd3522efa79db5/srcpkgs/maim/template)
 * [FreeBSD: graphics/maim](http://www.freshports.org/graphics/maim/)
 * Please make a package for maim on your favorite system, and make a pull request to add it to this list.
 


### PR DESCRIPTION
Not sure whether to link to http://repo.voidlinux.eu/current/ or the template that I constructed, which was processed by the buildbot after the merge.
