### PR TITLE
Compiler extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR
      "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
      "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel" )
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-parameter" )
-    set( CMAKE_CXX_FLAGS_DEBUG "-Wextra -pedantic-errors -O0 -g" )
+    set( CMAKE_CXX_FLAGS_DEBUG "-Wextra -pedantic -O0 -g" )
     set( CMAKE_CXX_FLAGS_RELEASE "-O2" )
     set( CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g" )
          # -Wall:   Enable all warnings.

--- a/src/im.cpp
+++ b/src/im.cpp
@@ -132,7 +132,7 @@ int maim::IMEngine::blendCursor( Window id, int x, int y ) {
     // I'm guessing this is because some old AMD cpu's longs are actually 32 bits.
     // Regardless this is how I convert it to the correct bit length.
     const size_t size_px = xcursor->width * xcursor->height;
-    DATA32 pixels [ size_px ] = { 0x0 };
+    DATA32 pixels [ size_px ];
 
     for ( unsigned int i=0;i<size_px;i++ ) {
         pixels[ i ] = (uint32_t)xcursor->pixels[ i ];


### PR DESCRIPTION
- Variable Length Array are not permitted in C++11 but in compilers gcc and clang,
is permitted as an extension.
- Change -pedantic-errors to -pedantic

Warnning: Intel compiler: I do not know.

https://github.com/naelstrof/maim/blob/master/src/im.cpp#L135

Testing OK:

cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=clang++

cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_COMPILER=g++
