### PR TITLE
Fix window mode

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,9 +286,13 @@ int app( int argc, char** argv ) {
     }
     if ( !maimOptions->parentGiven ) {
         maimOptions->parent = maimOptions->window;
+    } else if ( !maimOptions->geometryGiven ) {
+        throw new std::invalid_argument( "Relative mode (--parent) requires --geometry." );
     }
     if ( !maimOptions->geometryGiven ) {
         maimOptions->geometry = getWindowGeometry( x11, maimOptions->window );
+        maimOptions->geometry.x = 0;
+        maimOptions->geometry.y = 0;
     }
 
     if ( !maimOptions->select ) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -184,7 +184,7 @@ bool Options::getInt( std::string name, char namec, int& found ) {
                 throw new std::invalid_argument("Expected `=` after " + arguments[i]);
             }
             std::string::size_type sz;
-            float retvar;
+            int retvar;
             try {
                 retvar = std::stoi(values[i],&sz);
             } catch ( ... ) {
@@ -311,7 +311,7 @@ bool Options::getWindow( std::string name, char namec, Window& found, Window roo
                 return true;
             }
             std::string::size_type sz;
-            float retvar;
+            int retvar;
             try {
                 retvar = std::stoi(values[i],&sz);
             } catch ( ... ) {


### PR DESCRIPTION
The first commit fixes a rounding error causing maim to use the wrong window ID (#77).

The second commit fixes the default geometry being absolute (relative to the root window) and thus going out of the window's bounds. Pretty sure this was the problem in #70 and #71 all along.