### PR TITLE
Fix installation error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ cmake -DCMAKE_INSTALL_PREFIX="/usr" ./
 make && sudo make install
 cd ..
 git clone https://github.com/naelstrof/maim.git
+cd maim
 cmake -DCMAKE_INSTALL_PREFIX="/usr" ./
 make && sudo make install
 ```


### PR DESCRIPTION
There should be a `cd maim` before the second `cmake` command.