### PR TITLE
Ignore cmake generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ CMakeFiles/*
 Makefile
 cmake_install.cmake
 CMakeCache.txt
+
+# Ignore output artifacts
+bin/maim

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 # These files are ignored since cmake generates them from cmdline.in
 src/cmdline.h
+
+# Ignore Cmake generated files
+CMakeFiles/*
+Makefile
+cmake_install.cmake
+CMakeCache.txt


### PR DESCRIPTION
Since these files are never meant to be committed, adding them to the ignore lists.