### PR TITLE
FindSLOP is broken

### DIFF
--- a/modules/FindSLOP.cmake
+++ b/modules/FindSLOP.cmake
@@ -8,7 +8,7 @@
 #
 
 
-find_path( SLOP_INCLUDE_DIRS
+find_path( SLOP_INCLUDE_DIR
            NAMES slop.hpp
            PATH_SUFFIXES /usr/include /include
            DOC "The SLOP include directory" )


### PR DESCRIPTION
`find_path()` populates `SLOP_INCLUDE_DIRS`, but everywhere else refers to this variable as `SLOP_INCLUDE_DIR`.

