### PR TITLE
FIX typo in manpage for geometry selection

### DIFF
--- a/maim.1
+++ b/maim.1
@@ -25,7 +25,7 @@ Sets the desired output format, by default maim will attempt to determine the de
 Sets the desired window to capture, defaults to the root window. Allows for an integer, hex, or `root` for input.
 .TP
 .BR \-g ", " \-\-geometry=\fIGEOMETRY\fR
-Sets the region to capture, uses local coordinates from the given window. So -g10x30-5+0 would represent the rectangle wxh+x+y where w=10, h=30, x=-5, and y=0. x and y are the upper left location of this rectangle.
+Sets the region to capture, uses local coordinates from the given window. So -g 10x30-5+0 would represent the rectangle wxh+x+y where w=10, h=30, x=-5, and y=0. x and y are the upper left location of this rectangle.
 .TP
 .BR \-w ", " \-\-parent=\fIWINDOW\fR
 By default, maim assumes the --geometry values are in respect to the provided --window (or root if not provided). This parameter overrides this behavior by making the geometry be in respect to whatever window you provide to --parent. Allows for an integer, hex, or `root` for input.


### PR DESCRIPTION
There was a typo on the manpage for geoemetry selections. The indicated usage was an invalid flag, and because it was not recognized, ended up creating files with the flag as its name. A simple space corrects this issue as noted by https://github.com/naelstrof/maim/issues/119#issuecomment-339659744

Closes https://github.com/naelstrof/maim/issues/119