### PR TITLE
Fix building with IJG jpeg

### DIFF
--- a/src/image.cpp
+++ b/src/image.cpp
@@ -187,8 +187,8 @@ void ARGBImage::writeJPEG( std::ostream& streamout, int quality ) {
  
     jpeg_set_defaults(&cinfo);
     // Convert quality from scale 1-10 to 0-100
-    jpeg_set_quality (&cinfo, (int)((float)quality-1.f)*(100.f/9.f), true);
-    jpeg_start_compress(&cinfo, true);
+    jpeg_set_quality (&cinfo, (int)((float)quality-1.f)*(100.f/9.f), TRUE);
+    jpeg_start_compress(&cinfo, TRUE);
  
     JSAMPROW row_pointer;
     unsigned char* buffer    = (unsigned char*)data;


### PR DESCRIPTION
IJG's jpeg uses an enum to create a pseudo-boolean
value, and the only portable way to share its API
and libjpeg-turbo's API is to rely only on the
macros.

Bug: https://bugs.gentoo.org/656520

@naelstrof I tested this against libjpeg-turbo **and** IJG jpeg