### PR TITLE
Add support for 24-bit BMP images.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 maim (Make Image) is a utility that takes screenshots of your desktop. It's meant to overcome shortcomings of scrot and performs better in several ways.
 
 ## Features
-* Takes screenshots of your desktop, and saves it in png or jpg format.
+* Takes screenshots of your desktop, and saves it in png, jpg, or bmp format.
 * Takes screenshots predetermined regions or windows, useful for automation.
 * Allows a users to select a region, or window, before taking a screenshot on the fly.
 

--- a/maim.1
+++ b/maim.1
@@ -6,7 +6,7 @@ maim \- make image
 .SH SYNOPSIS
 maim [OPTIONS] [FILEPATH]
 .SH DESCRIPTION
-maim (make image) is an utility that takes a screenshot of your desktop, and encodes a png or jpg image of it. By default it outputs the encoded image data directly to standard output.
+maim (make image) is an utility that takes a screenshot of your desktop, and encodes a png, jpg, or bmp image of it. By default it outputs the encoded image data directly to standard output.
 .SH OPTIONS
 .TP
 .BR \-h ", " \-\-help
@@ -19,7 +19,7 @@ Print version and exit.
 Sets the xdisplay to use.
 .TP
 .BR \-f ", " \-\-format=\fISTRING\fR
-Sets the desired output format, by default maim will attempt to determine the desired output format automatically from the output file. If that fails it defaults to a lossless png format. Currently only supports `png` or `jpg`.
+Sets the desired output format, by default maim will attempt to determine the desired output format automatically from the output file. If that fails it defaults to a lossless png format. Currently only supports `png`, `jpg`, and `bmp`.
 .TP
 .BR \-i ", " \-\-window=\fIWINDOW\fR
 Sets the desired window to capture, defaults to the root window. Allows for an integer, hex, or `root` for input.
@@ -40,7 +40,7 @@ Sets the time in seconds to wait before taking a screenshot. Prints a simple mes
 By default maim super-imposes the cursor onto the image, you can disable that behavior with this flag.
 .TP
 .BR \-m ", " \-\-quality
-An integer from 1 to 10 that determines the compression quality. 1 is the highest (and lossiest) compression available for the provided format. For example a setting of `1` with png (a lossless format) would increase filesize and decrease decoding time. While a setting of `1` on a jpeg would create a pixel mush.
+An integer from 1 to 10 that determines the compression quality. 1 is the highest (and lossiest) compression available for the provided format. For example a setting of `1` with png (a lossless format) would increase filesize and decrease decoding time. While a setting of `1` on a jpeg would create a pixel mush. No effect on bmp images.
 .TP
 .BR \-s ", " \-\-select
 Enables an interactive selection mode where you may select the desired region or window before a screenshot is captured. Uses the settings below to determine the visuals and settings of slop.

--- a/src/image.hpp
+++ b/src/image.hpp
@@ -90,6 +90,7 @@ public:
     ~ARGBImage();
     void writePNG( std::ostream& streamout, int quality );
     void writeJPEG( std::ostream& streamout, int quality );
+    void writeBMP( std::ostream& streamout );
 };
 
 #endif


### PR DESCRIPTION
This adds support for 24 bit RGB bitmaps without adding extra dependencies. I've tested it with RGBA and it seems to work just fine with the images being understood by the programs I tested, but there's an expanded header format for that and it'd be better to use a proper BMP library at that point to guarantee compatibility. I figure most people using BMP don't expect it to support transparency anyway.

For my desktop the improvement is from around 1.2 seconds with minimum quality PNGs to 360ms.