### PR TITLE
replace broken CRUX port link by link to CRUX search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ maim (Make Image) is a utility that takes screenshots of your desktop. It's mean
 * [CRUX: maim](https://crux.nu/portdb/?a=search&q=maim)
 * [Gentoo: media-gfx/maim](https://packages.gentoo.org/packages/media-gfx/maim)
 * [NixOS: maim](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/graphics/maim/default.nix)
-* [GNU Guix: maim](https://www.gnu.org/software/guix/packages/#maim)
+* [GNU Guix: maim](https://guix.gnu.org/en/packages/maim-5.6.3/)
 * [Ravenports: maim](http://www.ravenports.com/catalog/bucket_B4/maim/standard/)
 * [Fedora: maim](https://src.fedoraproject.org/rpms/maim)
 * Please make a package for maim on your favorite system, and make a pull request to add it to this list.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ maim (Make Image) is a utility that takes screenshots of your desktop. It's mean
 * [FreeBSD: graphics/maim](http://www.freshports.org/graphics/maim/)
 * [NetBSD: x11/maim](http://pkgsrc.se/x11/maim)
 * [OpenBSD: graphics/maim](http://openports.se/graphics/maim)
-* [CRUX: 6c37/maim](https://github.com/6c37/crux-ports/tree/3.3/maim)
+* [CRUX: maim](https://crux.nu/portdb/?a=search&q=maim)
 * [Gentoo: media-gfx/maim](https://packages.gentoo.org/packages/media-gfx/maim)
 * [NixOS: maim](https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/graphics/maim/default.nix)
 * [GNU Guix: maim](https://www.gnu.org/software/guix/packages/#maim)


### PR DESCRIPTION
That's probably the best idea since maim is packaged in CRUX within two different collections and this could change any time in future.

Closes #220