### PR TITLE
catch all C++ exceptions and print error message

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <cstdlib>
 #include <unistd.h>
 #include <iostream>
 #include <exception>
@@ -624,7 +625,7 @@ static void handle_exception(std::exception_ptr eptr) {
         }
     } catch( const std::exception& e) {
         std::cerr << "Maim encountered an error:\n" << e.what() << "\n";
-        exit(1);
+        std::exit(1);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include <cstdio>
 #include <unistd.h>
 #include <iostream>
+#include <exception>
+#include <stdexcept>
 #include <slop.hpp>
 #include <glm/glm.hpp>
 #include <fstream>
@@ -615,12 +617,24 @@ int app( int argc, char** argv ) {
     return 0;
 }
 
+static void handle_exception(std::exception_ptr eptr) {
+    try {
+        if (eptr) {
+            std::rethrow_exception(eptr);
+        }
+    } catch( const std::exception& e) {
+        std::cerr << "Maim encountered an error:\n" << e.what() << "\n";
+        exit(1);
+    }
+}
+
 int main( int argc, char** argv ) {
+    std::exception_ptr e;
     try {
         return app( argc, argv );
-    } catch( std::exception* e ) {
-        std::cerr << "Maim encountered an error:\n" << e->what() << "\n";
-        return 1;
-    } // let the operating system handle any other kind of exception.
+    } catch( ... ) {
+        e = std::current_exception();
+    }
+    handle_exception(e);
     return 1;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,4 @@
 #include <cstdio>
-#include <cstdlib>
 #include <unistd.h>
 #include <iostream>
 #include <exception>
@@ -625,7 +624,6 @@ static void handle_exception(std::exception_ptr eptr) {
         }
     } catch( const std::exception& e) {
         std::cerr << "Maim encountered an error:\n" << e.what() << "\n";
-        std::exit(1);
     }
 }
 


### PR DESCRIPTION
Before this commit, maim did not catch every exception,
so sometimes it could print scary message into terminal.
Now the message looks a bit less scary :)

The changes introduced are valid portable C++11 as descibed here: https://en.cppreference.com/w/cpp/error/current_exception

I decided to do this PR after I have seen #191: because exception have not been caught, user erroneously decided maim has crashed and submitted this funny issue.