### PR TITLE
Do not crash when invalid cmd args are provided.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -618,6 +618,10 @@ int app( int argc, char** argv ) {
 int main( int argc, char** argv ) {
     try {
         return app( argc, argv );
+    } catch ( const cxxopts::OptionException& e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << "Try \"maim --help\" for more information." << std::endl;
+        return 1;
     } catch( std::exception* e ) {
         std::cerr << "Maim encountered an error:\n" << e->what() << "\n";
         return 1;


### PR DESCRIPTION
Before:
```bash
$ maim --invalid-arg
terminate called after throwing an instance of 'cxxopts::option_not_exists_exception'
  what():  Option ‘invalid-arg’ does not exist
[1]    30059 abort (core dumped)  maim --invalid-arg
```

After:
```bash
$ maim --invalid-arg
Option ‘invalid-arg’ does not exist
Try "maim --help" for more information.
```
