### PR TITLE
cmake should check if required GLM is installed.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ find_package( XComposite REQUIRED )
 find_package( X11        REQUIRED )
 find_package( SLOP       REQUIRED )
 find_package( Threads    REQUIRED )
+find_package( GLM        REQUIRED )
 
 set_property(TARGET ${BIN_TARGET} PROPERTY CXX_STANDARD_REQUIRED ON)
 set_property(TARGET ${BIN_TARGET} PROPERTY CXX_STANDARD 11)
@@ -47,6 +48,7 @@ set_property(TARGET ${BIN_TARGET} PROPERTY CXX_EXTENSIONS OFF)
 include_directories( ${XRANDR_INCLUDE_DIR}
                      ${X11_INCLUDE_DIR}
                      ${SLOP_INCLUDE_DIR}
+                     ${GLM_INCLUDE_DIR}
                      ${XFIXES_INCLUDE_DIR}
                      ${XCOMPOSITE_INCLUDE_DIR}
                      ${JPEG_INCLUDE_DIR}

--- a/modules/FindGLM.cmake
+++ b/modules/FindGLM.cmake
@@ -1,0 +1,20 @@
+# - Find GLM
+# Find the GLM libraries
+#
+#  This module defines the following variables:
+#     GLM_FOUND       - 1 if GLM_INCLUDE_DIR is found, 0 otherwise
+#     GLM_INCLUDE_DIR - where to find glm/glm.hpp
+#
+
+find_path( GLM_INCLUDE_DIR
+           NAMES glm/glm.hpp
+           PATH_SUFFIXES /usr/include /include
+           DOC "The GLM include directory" )
+
+if( GLM_INCLUDE_DIR )
+    set( GLM_FOUND 1 )
+else()
+    set( GLM_FOUND 0 )
+endif()
+
+mark_as_advanced( GLM_INCLUDE_DIR )


### PR DESCRIPTION
If GLM is not installed, cmake command will fail on missing dependency instead of compiler on missing header file.
