### PR TITLE
Fix hexadecimal parsing in parseWindow()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -60,7 +60,7 @@ Window parseWindow( std::string win, X11* x11 ) {
     Window retwin;
     std::string::size_type sz;
     try {
-        retwin = std::stoi(win,&sz);
+        retwin = std::stoi(win,&sz,0);
     } catch ( ... ) {
         try {
             retwin = std::stoul(win,&sz,16);


### PR DESCRIPTION
Due to invalid usage of std::stoi() hexadecimal
values prefixed with "0x" were always parsed
as integers with value of 0.

This fix uses base 0 instead of default base 10,
leading to automatic base detection.

Closes #234