### PR TITLE
Do not default to Debug build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,6 @@ cmake_minimum_required( VERSION 3.1.3 )
 
 project(maim VERSION 5.7.4 LANGUAGES CXX)
 
-if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE "Debug")
-endif()
-
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "/usr" CACHE PATH "..." FORCE)
 endif()

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ maim (Make Image) is a utility that takes screenshots of your desktop. It's mean
 ```bash
 git clone https://github.com/naelstrof/slop.git
 cd slop
-cmake -DCMAKE_INSTALL_PREFIX="/usr" ./
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="/usr" ./
 make && sudo make install
 cd ..
 git clone https://github.com/naelstrof/maim.git
 cd maim
-cmake -DCMAKE_INSTALL_PREFIX="/usr" ./
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="/usr" ./
 make && sudo make install
 ```
 


### PR DESCRIPTION
Also point occasional users to build with Release build type.

This makes it a bit easier for distribution maintainers to package maim. Also now occasional users will build optimized binaries if they follow instructions in README.

Closes #168.