### PR TITLE
Improve man page for better apropos results

### DIFF
--- a/maim.1
+++ b/maim.1
@@ -1,8 +1,8 @@
 .\" Manpage for maim.
 .\" Contact naelstrof@gmail.com to correct errors or typos.
-.TH maim 1 2017-03-21 Linux "maim man page"
+.TH maim 1 2021-02-03 Linux "maim man page"
 .SH NAME
-maim \- make image
+maim \- capture screenshot of desktop and make image
 .SH SYNOPSIS
 maim [OPTIONS] [FILEPATH]
 .SH DESCRIPTION


### PR DESCRIPTION
The man page could be improved to have better apropos(1) results. IOW,
to make the program appear with search terms that come to mind first,
as "make image" is true but too abstract. See attached patch.

Background: I was looking for avaliable screenshot tools, I knew I had
more installed and had no idea why at least one was missing. I ended
finding it again because I remembered about slop (which IMHO could
also get the man page name section improved), "apropos select"
worked. The use will be a bash oneliner like "zbarimg -q <( maim -f
png ) | xsel" to decode barcodes that are on screen and load them into
the selection.

This is forwarded from a Debian bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=981706