### PR TITLE
Added Alpine Linux package link on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ maim (Make Image) is an utility that takes screenshots of your desktop. It's mea
 * [GNU Guix: maim](https://guix.gnu.org/en/packages/maim-5.6.3/)
 * [Ravenports: maim](http://www.ravenports.com/catalog/bucket_B4/maim/standard/)
 * [Fedora: maim](https://src.fedoraproject.org/rpms/maim)
+* [Alpine Linux: maim](https://pkgs.alpinelinux.org/packages?name=maim&branch=edge&repo=&arch=&maintainer=)
 * Please make a package for maim on your favorite system, and make a pull request to add it to this list.
 
 ### Install using CMake (Requires CMake, git, libXrender, libXfixes, libGLM, libxcomposite, libxrandr, libxext, GLEW)


### PR DESCRIPTION
Alpine Linux has had the `maim` package on their official repositories for a while now.
This PR adds a link to the Alpine Linux package on the README.