### PR TITLE
Add note about Fedora EPEL (RHEL and CentOS) builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ maim (Make Image) is an utility that takes screenshots of your desktop. It's mea
 * [GNU Guix: maim](https://packages.guix.gnu.org/packages/maim/)
 * [Ravenports: maim](http://www.ravenports.com/catalog/bucket_B4/maim/standard/)
 * [Fedora: maim](https://src.fedoraproject.org/rpms/maim)
+* [Fedora EPEL (RHEL, CentOS): maim](https://src.fedoraproject.org/rpms/maim)
 * [Alpine Linux: maim](https://pkgs.alpinelinux.org/packages?name=maim&branch=edge&repo=&arch=&maintainer=)
 * Please make a package for maim on your favorite system, and make a pull request to add it to this list.
 


### PR DESCRIPTION
maim has been built for Fedora EPEL 9[1], which makes it available on CentOS and RHEL.  Tracked in Fedora Bugzilla[2] and Bodhi[3]

The URL is the same because it leads to maim in the Fedora source tracking system, which is shared for all Fedora, projects, but EPEL builds are separate.

 [1]: https://docs.fedoraproject.org/en-US/epel/
 [2]: https://bugzilla.redhat.com/show_bug.cgi?id=2262500
 [3]: https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2024-d0dc19e5cd