### PR TITLE
bump CMake minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.1.3 )
+cmake_minimum_required( VERSION 3.5.0 )
 
 project(maim VERSION 5.8.0 LANGUAGES CXX)
 


### PR DESCRIPTION
maim won't build with CMake 4.0+ as it removed compatibility with CMake <3.5, so this pull request bumps the minimum version to 3.5.0.