### PR TITLE
feat(paths): use stdout if savepath is "-"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -522,7 +522,7 @@ int app( int argc, char** argv ) {
     }
 
     std::ostream* out;
-    if ( maimOptions->savepathGiven ) {
+    if ( maimOptions->savepathGiven && maimOptions->savepath != "-" ) {
         std::ofstream* file = new std::ofstream();
         file->open(maimOptions->savepath.c_str());
         if ( !file->is_open() ) {
@@ -593,7 +593,7 @@ int app( int argc, char** argv ) {
 
     XDestroyImage( image );
 
-    if ( maimOptions->savepathGiven ) {
+    if ( maimOptions->savepathGiven && maimOptions->savepath != "-" ) {
         std::ofstream* file = (std::ofstream*)out;
         file->close();
         delete (std::ofstream*)out;


### PR DESCRIPTION
## What's being done here?

I added a check to see if the file is being saved as `-`. In which case, it will redirect it's output to stdout without having to use a pipe operator. This standard exists in many screenshotting applications and I wanted to apply it here.

## What is this for?

I have a script I use for i3 and I am designing my own error handling since `/bin/sh` doesn't have anyway to immediately halt a script if something like maim goes wrong. One of the things I took notice to when saving to `-` was that it was *literally* saving to `-`. I have tested this PR and it seems to have done [exactly what I wanted.](https://0x0.st/Kizo.png)